### PR TITLE
Add gl4_1_gears demo and fix a minor consistent spelling error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ else ()
 endif ()
 
 if (OPENGL_EXAMPLES)
-    foreach(prog IN ITEMS gl1_gears gl2_gears gl3_gears gl4_gears)
+    foreach(prog IN ITEMS gl1_gears gl2_gears gl3_gears gl4_1_gears gl4_gears)
         message("-- Adding: ${prog}")
         add_executable(${prog} src/${prog}.c)
         target_link_libraries(${prog} ${GLFW_LIBS_ALL} ${OPENGL_LOADER_LIBS})

--- a/shaders/gears.v410.frag
+++ b/shaders/gears.v410.frag
@@ -1,0 +1,18 @@
+#version 410
+
+layout (location = 0) in vec3 v_normal;
+layout (location = 1) in vec4 v_color;
+layout (location = 2) in vec3 v_fragPos;
+layout (location = 3) in vec3 v_lightDir;
+
+layout (location = 0) out vec4 outFragColor;
+
+void main()
+{
+  float ambient = 0.1;
+  float diff = max(dot(v_normal, v_lightDir), 0.0);
+
+  vec4 finalColor = (ambient + diff) * v_color;
+
+  outFragColor = vec4(finalColor.rgb, v_color.a);
+}

--- a/shaders/gears.v410.vert
+++ b/shaders/gears.v410.vert
@@ -1,0 +1,33 @@
+#version 410
+
+layout (location = 0) in vec3 a_pos;
+layout (location = 1) in vec3 a_normal;
+layout (location = 2) in vec4 a_color;
+
+uniform UBO
+{
+	mat4 projection;
+	mat4 model;
+	mat4 view;
+	vec3 lightpos;
+} ubo;
+
+layout (location = 0) out vec3 v_normal;
+layout (location = 1) out vec4 v_color;
+layout (location = 2) out vec3 v_fragPos;
+layout (location = 3) out vec3 v_lightDir;
+
+void main()
+{
+	mat4 modelView = ubo.view * ubo.model;
+	vec4 pos = modelView * vec4(a_pos,1.0);
+
+	mat3 normalMatrix = transpose(inverse(mat3(modelView)));
+
+	v_normal = normalize(normalMatrix * a_normal);
+	v_color = a_color;
+	v_fragPos = vec3(ubo.model * vec4(a_pos,1.0));
+	v_lightDir = normalize(ubo.lightpos - v_fragPos);
+
+	gl_Position = ubo.projection * pos;
+}

--- a/src/gl2_util.h
+++ b/src/gl2_util.h
@@ -102,7 +102,7 @@ static size_t index_buffer_size(index_buffer *ib);
 static uint index_buffer_count(index_buffer *ib);
 static void index_buffer_add(index_buffer *ib,
     const uint *data, uint count, uint addend);
-static void index_buffer_add_primitves(index_buffer *ib,
+static void index_buffer_add_primitives(index_buffer *ib,
     primitive_type type, uint count, uint addend);
 
 /*
@@ -215,7 +215,7 @@ static void index_buffer_add(index_buffer *ib,
     }
 }
 
-static void index_buffer_add_primitves(index_buffer *ib,
+static void index_buffer_add_primitives(index_buffer *ib,
     primitive_type type, uint count, uint addend)
 {
     static const uint tri[] = {0,1,2};

--- a/src/gl3_gears.c
+++ b/src/gl3_gears.c
@@ -118,7 +118,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
             vertex_3f(r1*ca3, r1*sa3, width*0.5f, nr1*ca3, nr1*sa3);
         }
     }
-    index_buffer_add_primitves(ib, primitive_topology_quad_strip, teeth*2, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quad_strip, teeth*2, idx);
 
     /* draw front sides of teeth */
     da = 2.f*(float) M_PI / teeth / 4.f;
@@ -138,7 +138,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
         vertex_3f(r2*ca2, r2*sa2, width*0.5f, nr2*ca2, nr2*sa2);
         vertex_3f(r1*ca3, r1*sa3, width*0.5f, nr1*ca3, nr1*sa3);
     }
-    index_buffer_add_primitves(ib, primitive_topology_quads, teeth, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quads, teeth, idx);
 
     normal_3f(0.f, 0.f, -1.f);
 
@@ -157,7 +157,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
             vertex_3f(r0*ca0, r0*sa0, -width*0.5f, nr0*ca0, nr0*sa0);
         }
     }
-    index_buffer_add_primitves(ib, primitive_topology_quad_strip, teeth*2, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quad_strip, teeth*2, idx);
 
     /* draw back sides of teeth */
     da = 2.f*(float) M_PI / teeth / 4.f;
@@ -177,7 +177,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
         vertex_3f(r2*ca1, r2*sa1, -width*0.5f, nr2*ca1, nr2*sa1);
         vertex_3f(r1*ca0, r1*sa0, -width*0.5f, nr1*ca0, nr1*sa0);
     }
-    index_buffer_add_primitves(ib, primitive_topology_quads, teeth, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quads, teeth, idx);
 
     /* draw outward faces of teeth */
     idx = vertex_buffer_count(vb);
@@ -220,7 +220,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
         vertex_3f(r1*ca4, r1*sa4, -width*0.5f, nr1*ca4, nr1*sa4);
         vertex_3f(r1*ca4, r1*sa4,  width*0.5f, nr1*ca4, nr1*sa4);
     }
-    index_buffer_add_primitves(ib, primitive_topology_quads, teeth*4, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quads, teeth*4, idx);
 
     /* draw inside radius cylinder */
     idx = vertex_buffer_count(vb);
@@ -232,7 +232,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
         vertex_3f(r0*ca0, r0*sa0, -width*0.5f, nr0*ca0, nr0*sa0);
         vertex_3f(r0*ca0, r0*sa0,  width*0.5f, nr0*ca0, nr0*sa0);
     }
-    index_buffer_add_primitves(ib, primitive_topology_quad_strip, teeth, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quad_strip, teeth, idx);
 }
 
 /*

--- a/src/gl4_1_gears.c
+++ b/src/gl4_1_gears.c
@@ -45,8 +45,10 @@
 #include "linmath.h"
 #include "gl2_util.h"
 
-static const char* frag_shader_filename = "shaders/gears.v120.fsh";
-static const char* vert_shader_filename = "shaders/gears.v120.vsh";
+static const char* frag_shader_glsl_filename = "shaders/gears.v410.frag";
+static const char* vert_shader_glsl_filename = "shaders/gears.v410.vert";
+
+static int help = 0;
 
 static GLfloat view_dist = -40.0f;
 static GLfloat view_rotx = 20.f, view_roty = 30.f, view_rotz = 0.f;
@@ -54,10 +56,19 @@ static GLfloat angle = 0.f;
 static int animation = 1;
 
 static GLuint program;
-static GLuint vbo[3], ibo[3];
+static GLuint ubo[3], vao[3], vbo[3], ibo[3];
 static vertex_buffer vb[3];
 static index_buffer ib[3];
 static mat4x4 gm[3], m, v, p, mvp;
+
+typedef struct UBO_t {
+    mat4x4 projection;
+    mat4x4 model;
+    mat4x4 view;
+    vec4 lightpos;
+} UBO_t;
+
+static struct UBO_t UBO[3];
 
 /*
  * Create a gear wheel.
@@ -255,18 +266,25 @@ static void draw(void)
     mat4x4_translate(m, -3.1f, 4.2f, 0.f);
     mat4x4_rotate_Z(gm[2], m, ((-2.f * angle - 25.f) / 180) * M_PI);
 
+    for(size_t i = 0; i < 3; i++) {
+        memcpy(UBO[i].model, &gm[i], sizeof(gm[i]));
+        memcpy(UBO[i].view, v, sizeof(v));
+    }
+
+    for(size_t i = 0; i < 3; i++) {
+        glBindBuffer(GL_UNIFORM_BUFFER, ubo[i]);
+        glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(UBO[i]), &UBO[i]);
+        glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    }
+
     glClearColor(0.0, 0.0, 0.0, 0.0);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    uniform_matrix_4fv("u_view", (const GLfloat *)v);
     for(size_t i = 0; i < 3; i++) {
-        uniform_matrix_4fv("u_model", (const GLfloat *)gm[i]);
+        glBindVertexArray(vao[i]);
         glBindBuffer(GL_ARRAY_BUFFER, vbo[i]);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibo[i]);
-        vertex_array_pointer("a_pos", 3, GL_FLOAT, 0, sizeof(vertex), offsetof(vertex,pos));
-        vertex_array_pointer("a_normal", 3, GL_FLOAT, 0, sizeof(vertex), offsetof(vertex,norm));
-        vertex_array_pointer("a_uv", 2, GL_FLOAT, 0, sizeof(vertex), offsetof(vertex,uv));
-        vertex_array_pointer("a_color", 4, GL_FLOAT, 0, sizeof(vertex), offsetof(vertex,col));
+        glBindBufferBase(GL_UNIFORM_BUFFER, 0, ubo[i]);
         glDrawElements(GL_TRIANGLES, (GLsizei)ib[i].count, GL_UNSIGNED_INT, (void*)0);
     }
 }
@@ -279,7 +297,9 @@ void reshape( GLFWwindow* window, int width, int height )
     GLfloat h = (GLfloat) height / (GLfloat) width;
     glViewport(0, 0, (GLint) width, (GLint) height);
     mat4x4_frustum(p, -1.0, 1.0, -h, h, 5.0, 60.0);
-    uniform_matrix_4fv("u_projection", (const GLfloat *)p);
+    for(size_t i = 0; i < 3; i++) {
+        memcpy(UBO[i].projection, p, sizeof(p));
+    }
 }
 
 /*
@@ -292,6 +312,13 @@ static void animate(void)
     }
 }
 
+static GLuint bind(GLuint program)
+{
+    GLuint blockIndex = glGetUniformBlockIndex(program, "UBO");
+    glUniformBlockBinding(program, blockIndex, 0);
+    return GL_TRUE;
+}
+
 /*
  * OpenGL initialization
  */
@@ -300,9 +327,9 @@ static void init(void)
     GLuint shaders[2];
 
     /* shader program */
-    shaders[0] = compile_shader(GL_VERTEX_SHADER, vert_shader_filename);
-    shaders[1] = compile_shader(GL_FRAGMENT_SHADER, frag_shader_filename);
-    program = link_program(shaders, 2, NULL);
+    shaders[0] = compile_shader(GL_VERTEX_SHADER, vert_shader_glsl_filename);
+    shaders[1] = compile_shader(GL_FRAGMENT_SHADER, frag_shader_glsl_filename);
+    program = link_program(shaders, 2, bind);
 
     /* create gear vertex and index buffers */
     for (size_t i = 0; i < 3; i++) {
@@ -314,14 +341,30 @@ static void init(void)
     gear(&vb[2], &ib[2], 1.3f, 2.f, 0.5f, 10, 0.7f,(vec4f){0.2f, 0.2f, 1.f, 1.f});
 
     /* create vertex array, vertex buffer and index buffer objects */
+    glGenVertexArrays(3, vao);
     for (size_t i = 0; i < 3; i++) {
+        glBindVertexArray(vao[i]);
         vertex_buffer_create(&vbo[i], GL_ARRAY_BUFFER, vb[i].data, vb[i].count * sizeof(vertex));
         vertex_buffer_create(&ibo[i], GL_ELEMENT_ARRAY_BUFFER, ib[i].data, ib[i].count * sizeof(uint));
+        vertex_array_pointer("a_pos", 3, GL_FLOAT, 0, sizeof(vertex), offsetof(vertex,pos));
+        vertex_array_pointer("a_normal", 3, GL_FLOAT, 0, sizeof(vertex), offsetof(vertex,norm));
+        vertex_array_pointer("a_uv", 2, GL_FLOAT, 0, sizeof(vertex), offsetof(vertex,uv));
+        vertex_array_pointer("a_color", 4, GL_FLOAT, 0, sizeof(vertex), offsetof(vertex,col));
+    }
+
+    glGenBuffers(3, ubo);
+    for(size_t i = 0; i < 3; i++) {
+        glBindBuffer(GL_UNIFORM_BUFFER, ubo[i]);
+        glBufferData(GL_UNIFORM_BUFFER, sizeof(UBO[i]), NULL, GL_DYNAMIC_DRAW);
+        glBindBuffer(GL_UNIFORM_BUFFER, 0);
     }
 
     /* set light position uniform */
     glUseProgram(program);
-    uniform_3f("u_lightpos", 5.f, 5.f, 10.f);
+    vec4 lightpos = { 5.f, 5.f, 10.f, 0.f };
+    for(size_t i = 0; i < 3; i++) {
+        memcpy(UBO[i].lightpos, lightpos, sizeof(lightpos));
+    }
 
     /* enable OpenGL capabilities */
     glEnable(GL_CULL_FACE);
@@ -352,12 +395,56 @@ void key( GLFWwindow* window, int k, int s, int action, int mods )
 }
 
 /*
+ * help text
+ */
+static void print_help(int argc, char **argv)
+{
+    fprintf(stderr,
+        "Usage: %s [options]\n"
+        "\n"
+        "Options:\n"
+        "  -h, --help                         command line help\n",
+        argv[0]);
+}
+
+/*
+ * command-line option parsing
+ */
+
+static int match_opt(const char *arg, const char *opt, const char *longopt)
+{
+    return strcmp(arg, opt) == 0 || strcmp(arg, longopt) == 0;
+}
+
+static void parse_options(int argc, char **argv)
+{
+    int i = 1;
+    while (i < argc) {
+        if (match_opt(argv[i], "-h", "--help")) {
+            help++;
+            i++;
+        } else {
+            fprintf(stderr, "error: unknown option: %s\n", argv[i]);
+            help++;
+            break;
+        }
+    }
+
+    if (help) {
+        print_help(argc, argv);
+        exit(1);
+    }
+}
+
+/*
  * main program
  */
 int main(int argc, char *argv[])
 {
     GLFWwindow* window;
     int width, height;
+
+    parse_options(argc, argv);
 
     if (!glfwInit())
     {
@@ -367,7 +454,7 @@ int main(int argc, char *argv[])
 
     glfwWindowHint(GLFW_DEPTH_BITS, 16);
     glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
 
     window = glfwCreateWindow(512, 512, "GL2 Gears", NULL, NULL);

--- a/src/gl4_gears.c
+++ b/src/gl4_gears.c
@@ -132,7 +132,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
             vertex_3f(r1*ca3, r1*sa3, width*0.5f, nr1*ca3, nr1*sa3);
         }
     }
-    index_buffer_add_primitves(ib, primitive_topology_quad_strip, teeth*2, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quad_strip, teeth*2, idx);
 
     /* draw front sides of teeth */
     da = 2.f*(float) M_PI / teeth / 4.f;
@@ -152,7 +152,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
         vertex_3f(r2*ca2, r2*sa2, width*0.5f, nr2*ca2, nr2*sa2);
         vertex_3f(r1*ca3, r1*sa3, width*0.5f, nr1*ca3, nr1*sa3);
     }
-    index_buffer_add_primitves(ib, primitive_topology_quads, teeth, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quads, teeth, idx);
 
     normal_3f(0.f, 0.f, -1.f);
 
@@ -171,7 +171,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
             vertex_3f(r0*ca0, r0*sa0, -width*0.5f, nr0*ca0, nr0*sa0);
         }
     }
-    index_buffer_add_primitves(ib, primitive_topology_quad_strip, teeth*2, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quad_strip, teeth*2, idx);
 
     /* draw back sides of teeth */
     da = 2.f*(float) M_PI / teeth / 4.f;
@@ -191,7 +191,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
         vertex_3f(r2*ca1, r2*sa1, -width*0.5f, nr2*ca1, nr2*sa1);
         vertex_3f(r1*ca0, r1*sa0, -width*0.5f, nr1*ca0, nr1*sa0);
     }
-    index_buffer_add_primitves(ib, primitive_topology_quads, teeth, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quads, teeth, idx);
 
     /* draw outward faces of teeth */
     idx = vertex_buffer_count(vb);
@@ -234,7 +234,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
         vertex_3f(r1*ca4, r1*sa4, -width*0.5f, nr1*ca4, nr1*sa4);
         vertex_3f(r1*ca4, r1*sa4,  width*0.5f, nr1*ca4, nr1*sa4);
     }
-    index_buffer_add_primitves(ib, primitive_topology_quads, teeth*4, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quads, teeth*4, idx);
 
     /* draw inside radius cylinder */
     idx = vertex_buffer_count(vb);
@@ -246,7 +246,7 @@ static void gear(vertex_buffer *vb, index_buffer *ib,
         vertex_3f(r0*ca0, r0*sa0, -width*0.5f, nr0*ca0, nr0*sa0);
         vertex_3f(r0*ca0, r0*sa0,  width*0.5f, nr0*ca0, nr0*sa0);
     }
-    index_buffer_add_primitves(ib, primitive_topology_quad_strip, teeth, idx);
+    index_buffer_add_primitives(ib, primitive_topology_quad_strip, teeth, idx);
 }
 
 /*

--- a/src/vk1_gears.c
+++ b/src/vk1_gears.c
@@ -196,7 +196,7 @@ static uint32_t gears_buffer_count(gears_buffer *vb);
 static uint32_t gears_buffer_add_vertex(gears_buffer *vb, gears_vertex vertex);
 static void gears_buffer_add_indices(gears_buffer *vb,
     const uint32_t *indices, uint32_t count, uint32_t addend);
-static void gears_buffer_add_indices_primitves(gears_buffer *vb,
+static void gears_buffer_add_indices_primitives(gears_buffer *vb,
     gears_primitive_type type, uint count, uint addend);
 
 void panic(const char *fmt, ...)
@@ -321,7 +321,7 @@ static void gears_buffer_add_indices(gears_buffer *vb,
     }
 }
 
-static void gears_buffer_add_indices_primitves(gears_buffer *vb,
+static void gears_buffer_add_indices_primitives(gears_buffer *vb,
     gears_primitive_type type, uint count, uint addend)
 {
     static const uint tri[] = {0,1,2};
@@ -1626,7 +1626,7 @@ gear(gears_buffer *vb, gears_buffer *ib,
             vertex_3f(r1*cosf(angle+3*da), r1*sinf(angle+3*da), width*0.5f);
         }
     }
-    gears_buffer_add_indices_primitves(ib, gears_topology_quad_strip, teeth*2, idx);
+    gears_buffer_add_indices_primitives(ib, gears_topology_quad_strip, teeth*2, idx);
 
     /* draw front sides of teeth */
     da = 2.f*(float) M_PI / teeth / 4.f;
@@ -1638,7 +1638,7 @@ gear(gears_buffer *vb, gears_buffer *ib,
         vertex_3f(r2*cosf(angle+2*da), r2*sinf(angle+2*da), width*0.5f);
         vertex_3f(r1*cosf(angle+3*da), r1*sinf(angle+3*da), width*0.5f);
     }
-    gears_buffer_add_indices_primitves(ib, gears_topology_quads, teeth, idx);
+    gears_buffer_add_indices_primitives(ib, gears_topology_quads, teeth, idx);
 
     normal_3f(0.0, 0.0, -1.0);
 
@@ -1653,7 +1653,7 @@ gear(gears_buffer *vb, gears_buffer *ib,
             vertex_3f(r0*cosf(angle), r0*sinf(angle), -width*0.5f);
         }
     }
-    gears_buffer_add_indices_primitves(ib, gears_topology_quad_strip, teeth*2, idx);
+    gears_buffer_add_indices_primitives(ib, gears_topology_quad_strip, teeth*2, idx);
 
     /* draw back sides of teeth */
     da = 2.f*(float) M_PI / teeth / 4.f;
@@ -1665,7 +1665,7 @@ gear(gears_buffer *vb, gears_buffer *ib,
         vertex_3f(r2*cosf(angle+1*da), r2*sinf(angle+1*da), -width*0.5f);
         vertex_3f(r1*cosf(angle), r1*sinf(angle), -width*0.5f);
     }
-    gears_buffer_add_indices_primitves(ib, gears_topology_quads, teeth, idx);
+    gears_buffer_add_indices_primitives(ib, gears_topology_quads, teeth, idx);
 
     /* draw outward faces of teeth */
     idx = gears_buffer_count(vb);
@@ -1698,7 +1698,7 @@ gear(gears_buffer *vb, gears_buffer *ib,
         vertex_3f(r1*cosf(angle+4*da), r1*sinf(angle+4*da), -width*0.5f);
         vertex_3f(r1*cosf(angle+4*da), r1*sinf(angle+4*da), width*0.5f);
     }
-    gears_buffer_add_indices_primitves(ib, gears_topology_quads, teeth*4, idx);
+    gears_buffer_add_indices_primitives(ib, gears_topology_quads, teeth*4, idx);
 
     /* draw inside radius cylinder */
     idx = gears_buffer_count(vb);
@@ -1708,7 +1708,7 @@ gear(gears_buffer *vb, gears_buffer *ib,
         vertex_3f(r0*cosf(angle), r0*sinf(angle), -width*0.5f);
         vertex_3f(r0*cosf(angle), r0*sinf(angle), width*0.5f);
     }
-    gears_buffer_add_indices_primitves(ib, gears_topology_quad_strip, teeth, idx);
+    gears_buffer_add_indices_primitives(ib, gears_topology_quad_strip, teeth, idx);
 }
 
 static void gears_destroy_vertex_buffers(gears_app *app)


### PR DESCRIPTION
This PR adds an additional demo for OpenGL 4.1.  The reason for doing that is that
4.1 is the newest version supported by Apple.  The existing gl4 demo based on
4.5 does not run on macOS.

The PR also fixes a spelling error.